### PR TITLE
Improve callable wrapping in Injector

### DIFF
--- a/anydi/_injector.py
+++ b/anydi/_injector.py
@@ -51,7 +51,11 @@ class Injector:
                 kwargs[name] = self.container.resolve(annotation)
             return cast(T, call(*args, **kwargs))
 
-        call.__inject_wrapper__ = wrapper  # type: ignore[attr-defined]
+        # check if the call is a method
+        if inspect.ismethod(call):
+            wrapper = wraps(call)(wrapper)
+        else:
+            call.__inject_wrapper__ = wrapper  # type: ignore[attr-defined]
 
         return wrapper
 


### PR DESCRIPTION
Currently I get:
`AttributeError: 'method' object has no attribute '__inject_wrapper__'`
When working with django-unfold library.
Look's like the issue is due to method callables not being handled.
I have implemented a temporary fix for that, feel free to reject this PR and create a better one.

Maybe it's better to just ignore method callables.
```
if not inspect.ismethod(call):
    call.__inject_wrapper__ = wrapper  # type: ignore[attr-defined]
return wrapper
```