### PR TITLE
feat(scopes): add isolated scope re-entry via replace flag

### DIFF
--- a/anydi/_container.py
+++ b/anydi/_container.py
@@ -171,18 +171,24 @@ class Container:
         await self._singleton_context.aclose()
 
     @contextlib.contextmanager
-    def scoped_context(self, scope: str) -> Iterator[InstanceContext]:
-        """Obtain a context manager for the request-scoped context."""
+    def scoped_context(
+        self, scope: str, *, replace: bool = False
+    ) -> Iterator[InstanceContext]:
+        """Obtain a context manager for the specified scoped context.
+
+        Reuses the currently active context if one exists, otherwise opens a
+        fresh one. With ``replace=True`` always opens a fresh, isolated context
+        that temporarily shadows any active one and is restored on exit.
+        """
         context_var = self._get_scoped_context_var(scope)
 
-        # Check if context already exists (re-entering same scope)
-        context = context_var.get(None)
-        if context is not None:
-            # Reuse existing context, don't create a new one
-            yield context
+        # Reuse the active context unless an isolated replacement is requested.
+        existing_context = context_var.get(None)
+        if existing_context is not None and not replace:
+            yield existing_context
             return
 
-        # Create new context
+        # Create new context (first entry, or a replacing re-entry)
         context = InstanceContext()
         token = context_var.set(context)
 
@@ -192,23 +198,31 @@ class Container:
                 continue
             self.resolve(dependency_type)
 
-        with context:
-            yield context
+        try:
+            with context:
+                yield context
+        finally:
             context_var.reset(token)
 
     @contextlib.asynccontextmanager
-    async def ascoped_context(self, scope: str) -> AsyncIterator[InstanceContext]:
-        """Obtain a context manager for the specified scoped context."""
+    async def ascoped_context(
+        self, scope: str, *, replace: bool = False
+    ) -> AsyncIterator[InstanceContext]:
+        """Obtain an async context manager for the specified scoped context.
+
+        Reuses the currently active context if one exists, otherwise opens a
+        fresh one. With ``replace=True`` always opens a fresh, isolated context
+        that temporarily shadows any active one and is restored on exit.
+        """
         context_var = self._get_scoped_context_var(scope)
 
-        # Check if context already exists (re-entering same scope)
-        context = context_var.get(None)
-        if context is not None:
-            # Reuse existing context, don't create a new one
-            yield context
+        # Reuse the active context unless an isolated replacement is requested.
+        existing_context = context_var.get(None)
+        if existing_context is not None and not replace:
+            yield existing_context
             return
 
-        # Create new context
+        # Create new context (first entry, or a replacing re-entry)
         context = InstanceContext()
         token = context_var.set(context)
 
@@ -218,8 +232,10 @@ class Container:
                 continue
             await self.aresolve(dependency_type)
 
-        async with context:
-            yield context
+        try:
+            async with context:
+                yield context
+        finally:
             context_var.reset(token)
 
     @contextlib.contextmanager
@@ -233,6 +249,34 @@ class Container:
         """Obtain an async context manager for the request-scoped context."""
         async with self.ascoped_context("request") as context:
             yield context
+
+    def get_scoped_context(self, scope: str) -> InstanceContext:
+        """Get the currently active context for the specified scope.
+
+        Returns the InstanceContext that is currently active for the given
+        scope name. This is useful when you need to access or modify the
+        current scope's context without creating a new one.
+
+        Raises:
+            LookupError: If the scope context has not been started.
+            ValueError: If the scope is reserved or not registered.
+        """
+        return self._get_scoped_context(scope)
+
+    def try_get_scoped_context(self, scope: str) -> InstanceContext | None:
+        """Get the currently active context for the specified scope, or None.
+
+        Like :meth:`get_scoped_context`, but returns None when the scope has
+        not been entered instead of raising ``LookupError``. This is the
+        non-throwing variant for callers that branch on whether a scope is
+        currently active (e.g. optional dependencies that fall back to a
+        no-op when a deeper scope is not present).
+
+        Raises:
+            ValueError: If the scope is reserved or not registered.
+        """
+        scoped_context_var = self._get_scoped_context_var(scope)
+        return scoped_context_var.get(None)
 
     def _get_scoped_context(self, scope: str) -> InstanceContext:
         scoped_context_var = self._get_scoped_context_var(scope)

--- a/anydi/_resolver.py
+++ b/anydi/_resolver.py
@@ -471,7 +471,8 @@ class Resolver:
         if with_override:
             create_lines.append("    if override_mode:")
             create_lines.append(
-                "        inst = resolver._post_resolve_override(_dependency_type, inst)"
+                "        inst = resolver._post_resolve_override("
+                "_dependency_type, inst, context)"
             )
         create_lines.append("    return inst")
 
@@ -747,7 +748,24 @@ class Resolver:
             return instance
         return InstanceProxy(instance, dependency_type=dependency_type)
 
-    def _post_resolve_override(self, dependency_type: Any, instance: Any) -> Any:
+    def _resolve_wrapped(self, dependency_type: Any, context: Any) -> Any:
+        """Resolve a wrapped dependency for the resolver getter.
+
+        Prefers an active override, then the captured scope context (so that
+        re-resolution during scope nesting reads from the correct scope), and
+        finally falls back to ``container.resolve()``.
+        """
+        if dependency_type in self._overrides:
+            return self._overrides[dependency_type]
+        if context is not None:
+            cached = context.get(dependency_type, NOT_SET)
+            if cached is not NOT_SET:
+                return cached
+        return self._container.resolve(dependency_type)
+
+    def _post_resolve_override(
+        self, dependency_type: Any, instance: Any, context: Any = None
+    ) -> Any:
         """Hook for patching resolved instances to support override."""
         if dependency_type in self._overrides:
             return self._overrides[dependency_type]
@@ -763,11 +781,13 @@ class Resolver:
             if isinstance(value, InstanceProxy)
         }
 
+        # Capture the context the instance was created in so that
+        # re-resolution during nesting reads from the correct scope.
+        captured_context = context
+
         def __resolver_getter__(name: str) -> Any:
             if name in wrapped:
-                _dependency_type = wrapped[name]
-                # Resolve the dependency if it's wrapped
-                return self._container.resolve(_dependency_type)
+                return self._resolve_wrapped(wrapped[name], captured_context)
             raise LookupError
 
         # Attach the resolver getter to the instance

--- a/docs/usage/scopes.md
+++ b/docs/usage/scopes.md
@@ -255,6 +255,42 @@ async def process_workflow() -> None:
             # Process workflow...
 ```
 
+### Re-entering an active scope
+
+Entering a scope that is already active reuses the active context by default (same `InstanceContext`, same instances). Pass `replace=True` to instead open a fresh, isolated context that temporarily shadows the active one and is restored on exit.
+
+The fresh context has its own instance cache and still resolves parent and `singleton` dependencies, but it does **not** inherit instances from the replaced context. When it exits, only its own instances are cleaned up.
+
+```python
+from anydi import Container
+
+
+class TaskContext:
+    def __init__(self, task_id: str) -> None:
+        self.task_id = task_id
+
+
+container = Container()
+container.register_scope("task")
+container.register(TaskContext, scope="task", from_context=True)
+
+with container.scoped_context("task") as outer:
+    outer.set(TaskContext, TaskContext(task_id="outer"))
+    assert container.resolve(TaskContext).task_id == "outer"
+
+    # Replace the active context with a fresh, isolated one
+    with container.scoped_context("task", replace=True) as inner:
+        inner.set(TaskContext, TaskContext(task_id="inner"))
+        assert container.resolve(TaskContext).task_id == "inner"
+
+    # The outer context is restored on exit
+    assert container.resolve(TaskContext).task_id == "outer"
+```
+
+This is useful when an inner unit of work needs its own isolated scope while an outer context of the same scope is still active.
+
+To access the currently active context without entering a new one, use `get_scoped_context(scope)` (raises `LookupError` if the scope is not active) or `try_get_scoped_context(scope)` (returns `None` instead). Prefer these for *reading* the active context — only call `scoped_context` / `ascoped_context` when you genuinely need to **start** a scope.
+
 ### Best practices
 
 1. **Clear hierarchies**: Structure scopes to match your application logic (e.g., `request` → `transaction` → `batch`)

--- a/tests/test_scope_replace.py
+++ b/tests/test_scope_replace.py
@@ -1,0 +1,653 @@
+"""Tests for isolated scope re-entry (scoped_context(scope, replace=True))."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass
+
+import pytest
+
+from anydi import Container
+
+from tests.fixtures import UniqueId
+
+
+@dataclass
+class ScopedValue:
+    label: str
+
+
+class DependentService:
+    def __init__(self, value: ScopedValue) -> None:
+        self.value = value
+
+
+@pytest.fixture
+def container() -> Container:
+    return Container()
+
+
+class TestReuseByDefault:
+    """Re-entering an active scope reuses its context unless replace=True."""
+
+    def test_reentry_reuses_context_by_default(self, container: Container) -> None:
+        """Re-entering a scope reuses the active context by default."""
+        container.register_scope("task")
+        container.register(str, lambda: "value", scope="task")
+
+        with container.scoped_context("task") as ctx1:
+            with container.scoped_context("task") as ctx2:
+                assert ctx1 is ctx2
+
+    async def test_async_reentry_reuses_context_by_default(
+        self, container: Container
+    ) -> None:
+        """Async re-entering a scope reuses the active context by default."""
+        container.register_scope("task")
+        container.register(str, lambda: "value", scope="task")
+
+        async with container.ascoped_context("task") as ctx1:
+            async with container.ascoped_context("task") as ctx2:
+                assert ctx1 is ctx2
+
+    def test_builtin_request_scope_reentry_reuses(self, container: Container) -> None:
+        """Request scope re-entry reuses the context by default."""
+        with container.request_context() as ctx1:
+            with container.request_context() as ctx2:
+                assert ctx1 is ctx2
+
+
+class TestReplaceScopeBasic:
+    """Tests for basic replace=True behavior."""
+
+    def test_replace_creates_new_context(self, container: Container) -> None:
+        """Replacing creates a fresh InstanceContext each time."""
+        container.register_scope("task")
+        container.register(str, lambda: "value", scope="task")
+
+        with container.scoped_context("task") as ctx_outer:
+            with container.scoped_context("task", replace=True) as ctx_inner:
+                assert ctx_outer is not ctx_inner
+
+    def test_replace_on_first_entry_creates_context(self, container: Container) -> None:
+        """replace=True on a first entry simply creates a context."""
+        container.register_scope("task")
+
+        with container.scoped_context("task", replace=True) as ctx:
+            assert container.get_scoped_context("task") is ctx
+
+    def test_replace_has_own_instance_cache(self, container: Container) -> None:
+        """Each nested scope has its own cache — instances are not shared."""
+        container.register_scope("task")
+
+        call_count = 0
+
+        def make_str() -> str:
+            nonlocal call_count
+            call_count += 1
+            return f"instance_{call_count}"
+
+        container.register(str, make_str, scope="task")
+
+        with container.scoped_context("task"):
+            outer_val = container.resolve(str)
+            assert outer_val == "instance_1"
+
+            with container.scoped_context("task", replace=True):
+                inner_val = container.resolve(str)
+                assert inner_val == "instance_2"
+                assert inner_val != outer_val
+
+    def test_replace_cleanup_does_not_affect_parent(self, container: Container) -> None:
+        """Exiting a nested scope restores the parent scope's instances."""
+        container.register_scope("task")
+
+        call_count = 0
+
+        def make_str() -> str:
+            nonlocal call_count
+            call_count += 1
+            return f"instance_{call_count}"
+
+        container.register(str, make_str, scope="task")
+
+        with container.scoped_context("task"):
+            outer_val = container.resolve(str)
+            assert outer_val == "instance_1"
+
+            with container.scoped_context("task", replace=True):
+                inner_val = container.resolve(str)
+                assert inner_val == "instance_2"
+
+            restored_val = container.resolve(str)
+            assert restored_val == outer_val
+
+    def test_replace_singleton_dependency(self, container: Container) -> None:
+        """Nested scopes can resolve singleton dependencies."""
+        container.register_scope("task")
+        container.register(int, lambda: 42, scope="singleton")
+
+        def make_str(x: int) -> str:
+            return f"value: {x}"
+
+        container.register(str, make_str, scope="task")
+
+        with container:
+            with container.scoped_context("task"):
+                outer_val = container.resolve(str)
+                assert outer_val == "value: 42"
+
+                with container.scoped_context("task", replace=True):
+                    inner_val = container.resolve(str)
+                    assert inner_val == "value: 42"
+
+    def test_replace_three_levels(self, container: Container) -> None:
+        """Three levels of nesting with from_context work correctly."""
+        container.register_scope("task")
+        container.register(ScopedValue, scope="task", from_context=True)
+
+        with container.scoped_context("task") as ctx1:
+            ctx1.set(ScopedValue, ScopedValue("level-1"))
+            assert container.resolve(ScopedValue).label == "level-1"
+
+            with container.scoped_context("task", replace=True) as ctx2:
+                ctx2.set(ScopedValue, ScopedValue("level-2"))
+                assert container.resolve(ScopedValue).label == "level-2"
+
+                with container.scoped_context("task", replace=True) as ctx3:
+                    ctx3.set(ScopedValue, ScopedValue("level-3"))
+                    assert container.resolve(ScopedValue).label == "level-3"
+
+                assert container.resolve(ScopedValue).label == "level-2"
+
+            assert container.resolve(ScopedValue).label == "level-1"
+
+    def test_replace_resource_cleanup(self, container: Container) -> None:
+        """Resources in nested scopes are cleaned up in correct order."""
+        container.register_scope("task")
+
+        cleanup_log: list[str] = []
+
+        @container.provider(scope="task")
+        def provide_str() -> Iterator[str]:
+            cleanup_log.append("start")
+            yield "resource"
+            cleanup_log.append("cleanup")
+
+        with container.scoped_context("task"):
+            container.resolve(str)
+
+            with container.scoped_context("task", replace=True):
+                container.resolve(str)
+
+            assert cleanup_log == ["start", "start", "cleanup"]
+
+        assert cleanup_log == ["start", "start", "cleanup", "cleanup"]
+
+    def test_replace_instance_caching_within_level(self, container: Container) -> None:
+        """Instances are cached within each nesting level."""
+        container.register_scope("task")
+        container.register(UniqueId, scope="task")
+
+        with container.scoped_context("task"):
+            id1 = container.resolve(UniqueId)
+            id2 = container.resolve(UniqueId)
+            assert id1 is id2
+
+            with container.scoped_context("task", replace=True):
+                id3 = container.resolve(UniqueId)
+                id4 = container.resolve(UniqueId)
+                assert id3 is id4
+                assert id3 is not id1
+
+
+class TestReplaceScopeAsync:
+    """Async replace behavior tests."""
+
+    async def test_async_replace_creates_new_context(
+        self, container: Container
+    ) -> None:
+        """Async replace creates a fresh InstanceContext each time."""
+        container.register_scope("task")
+        container.register(str, lambda: "value", scope="task")
+
+        async with container.ascoped_context("task") as ctx_outer:
+            async with container.ascoped_context("task", replace=True) as ctx_inner:
+                assert ctx_outer is not ctx_inner
+
+    async def test_async_replace_has_own_cache(self, container: Container) -> None:
+        """Async nested scopes have isolated from_context values."""
+        container.register_scope("task")
+        container.register(ScopedValue, scope="task", from_context=True)
+
+        async with container.ascoped_context("task") as ctx1:
+            ctx1.set(ScopedValue, ScopedValue("outer"))
+            assert (await container.aresolve(ScopedValue)).label == "outer"
+
+            async with container.ascoped_context("task", replace=True) as ctx2:
+                ctx2.set(ScopedValue, ScopedValue("inner"))
+                assert (await container.aresolve(ScopedValue)).label == "inner"
+
+            assert (await container.aresolve(ScopedValue)).label == "outer"
+
+    async def test_async_replace_resource_cleanup(self, container: Container) -> None:
+        """Async resources in nested scopes are cleaned up in correct order."""
+        container.register_scope("task")
+
+        cleanup_log: list[str] = []
+
+        @container.provider(scope="task")
+        async def provide_str() -> AsyncIterator[str]:
+            cleanup_log.append("start")
+            yield "resource"
+            cleanup_log.append("cleanup")
+
+        async with container.ascoped_context("task"):
+            await container.aresolve(str)
+
+            async with container.ascoped_context("task", replace=True):
+                await container.aresolve(str)
+
+            assert cleanup_log == ["start", "start", "cleanup"]
+
+        assert cleanup_log == ["start", "start", "cleanup", "cleanup"]
+
+
+class TestGetScopedContext:
+    """Tests for the public get_scoped_context() method."""
+
+    def test_get_scoped_context_returns_current(self, container: Container) -> None:
+        """Returns the active context for the specified scope."""
+        container.register_scope("task")
+
+        with container.scoped_context("task") as ctx:
+            assert container.get_scoped_context("task") is ctx
+
+    def test_get_scoped_context_returns_innermost(self, container: Container) -> None:
+        """Returns the innermost context when nested."""
+        container.register_scope("task")
+
+        with container.scoped_context("task") as ctx_outer:
+            assert container.get_scoped_context("task") is ctx_outer
+
+            with container.scoped_context("task", replace=True) as ctx_inner:
+                assert container.get_scoped_context("task") is ctx_inner
+
+            assert container.get_scoped_context("task") is ctx_outer
+
+    def test_get_scoped_context_raises_when_not_started(
+        self, container: Container
+    ) -> None:
+        """Raises LookupError when scope is not active."""
+        container.register_scope("task")
+
+        with pytest.raises(
+            LookupError,
+            match=r"The task context has not been started",
+        ):
+            container.get_scoped_context("task")
+
+    def test_try_get_scoped_context_returns_current(self, container: Container) -> None:
+        """try_get_scoped_context returns the active context when started."""
+        container.register_scope("task")
+
+        with container.scoped_context("task") as ctx:
+            assert container.try_get_scoped_context("task") is ctx
+
+    def test_try_get_scoped_context_returns_none_when_not_started(
+        self, container: Container
+    ) -> None:
+        """try_get_scoped_context returns None when the scope is not active."""
+        container.register_scope("task")
+
+        assert container.try_get_scoped_context("task") is None
+
+    def test_get_scoped_context_reserved_scope_raises(
+        self, container: Container
+    ) -> None:
+        """Raises ValueError for reserved scopes."""
+        with pytest.raises(ValueError, match=r"reserved scope"):
+            container.get_scoped_context("singleton")
+
+    def test_get_scoped_context_unregistered_scope_raises(
+        self, container: Container
+    ) -> None:
+        """Raises ValueError for unregistered scopes."""
+        with pytest.raises(ValueError, match=r"not registered scope"):
+            container.get_scoped_context("unknown")
+
+
+class TestReplaceScopeWithBuild:
+    """Tests that build() validation and compiled resolvers work with replace."""
+
+    def test_build_then_replace_resolution(self, container: Container) -> None:
+        """Nested resolution works after build() has compiled resolvers."""
+        container.register_scope("task")
+        container.register(int, lambda: 99, scope="singleton")
+        container.register(ScopedValue, scope="task", from_context=True)
+        container.register(DependentService, scope="task")
+
+        container.build()
+
+        with container:
+            with container.scoped_context("task") as ctx_a:
+                ctx_a.set(ScopedValue, ScopedValue("outer"))
+                svc_a = container.resolve(DependentService)
+                singleton_a = container.resolve(int)
+
+                with container.scoped_context("task", replace=True) as ctx_b:
+                    ctx_b.set(ScopedValue, ScopedValue("inner"))
+                    svc_b = container.resolve(DependentService)
+                    singleton_b = container.resolve(int)
+
+                    assert svc_a is not svc_b
+                    assert svc_b.value.label == "inner"
+                    assert singleton_a is singleton_b
+
+                assert container.resolve(DependentService) is svc_a
+                assert container.resolve(ScopedValue).label == "outer"
+
+    async def test_build_then_async_replace_resolution(
+        self, container: Container
+    ) -> None:
+        """Async nested resolution works after build()."""
+        container.register_scope("task")
+        container.register(ScopedValue, scope="task", from_context=True)
+        container.register(DependentService, scope="task")
+
+        container.build()
+
+        async with container.ascoped_context("task") as ctx_a:
+            ctx_a.set(ScopedValue, ScopedValue("outer"))
+            svc_a = await container.aresolve(DependentService)
+
+            async with container.ascoped_context("task", replace=True) as ctx_b:
+                ctx_b.set(ScopedValue, ScopedValue("inner"))
+                svc_b = await container.aresolve(DependentService)
+
+                assert svc_a is not svc_b
+                assert svc_b.value.label == "inner"
+
+            assert (await container.aresolve(ScopedValue)).label == "outer"
+            assert (await container.aresolve(DependentService)) is svc_a
+
+
+class TestReplaceScopeChain:
+    """End-to-end nested scope chain tests."""
+
+    def test_replace_chain(self, container: Container) -> None:
+        """Three-level nesting with context restoration on exit."""
+        container.register_scope("task")
+        container.register(ScopedValue, scope="task", from_context=True)
+        container.register(DependentService, scope="task")
+
+        log: list[str] = []
+
+        with container.scoped_context("task") as ctx1:
+            ctx1.set(ScopedValue, ScopedValue("L1"))
+            svc1 = container.resolve(DependentService)
+            log.append(f"start: {svc1.value.label}")
+
+            with container.scoped_context("task", replace=True) as ctx2:
+                ctx2.set(ScopedValue, ScopedValue("L2"))
+                svc2 = container.resolve(DependentService)
+                log.append(f"nested: {svc2.value.label}")
+
+                with container.scoped_context("task", replace=True) as ctx3:
+                    ctx3.set(ScopedValue, ScopedValue("L3"))
+                    svc3 = container.resolve(DependentService)
+                    log.append(f"nested: {svc3.value.label}")
+
+                assert container.resolve(ScopedValue).label == "L2"
+                log.append(f"resumed: {svc2.value.label}")
+
+            assert container.resolve(ScopedValue).label == "L1"
+            log.append(f"resumed: {svc1.value.label}")
+
+        assert log == [
+            "start: L1",
+            "nested: L2",
+            "nested: L3",
+            "resumed: L2",
+            "resumed: L1",
+        ]
+
+    async def test_async_replace_chain(self, container: Container) -> None:
+        """Async three-level nesting with context restoration."""
+        container.register_scope("task")
+        container.register(ScopedValue, scope="task", from_context=True)
+
+        async def make_service(value: ScopedValue) -> DependentService:
+            return DependentService(value)
+
+        container.register(DependentService, make_service, scope="task")
+
+        async with container.ascoped_context("task") as ctx1:
+            ctx1.set(ScopedValue, ScopedValue("L1"))
+            svc1 = await container.aresolve(DependentService)
+            assert svc1.value.label == "L1"
+
+            async with container.ascoped_context("task", replace=True) as ctx2:
+                ctx2.set(ScopedValue, ScopedValue("L2"))
+                svc2 = await container.aresolve(DependentService)
+                assert svc2.value.label == "L2"
+
+            assert (await container.aresolve(ScopedValue)).label == "L1"
+
+
+class TestReplaceScopeParallelAsync:
+    """Tests for concurrent replace via asyncio.gather / create_task."""
+
+    async def test_parallel_gather_isolated_contexts(
+        self, container: Container
+    ) -> None:
+        """Concurrent scopes via gather don't cross-contaminate."""
+        container.register_scope("task")
+        container.register(ScopedValue, scope="task", from_context=True)
+        container.register(DependentService, scope="task")
+
+        async def run_task(label: str) -> tuple[str, str]:
+            async with container.ascoped_context("task") as ctx:
+                ctx.set(ScopedValue, ScopedValue(label))
+                svc = await container.aresolve(DependentService)
+                await asyncio.sleep(0)
+                after = await container.aresolve(ScopedValue)
+                return svc.value.label, after.label
+
+        results = await asyncio.gather(
+            run_task("A"),
+            run_task("B"),
+            run_task("C"),
+        )
+
+        assert results == [("A", "A"), ("B", "B"), ("C", "C")]
+
+    async def test_parallel_gather_with_parent_scope(
+        self, container: Container
+    ) -> None:
+        """Parallel replaced scopes inside a parent scope don't affect the parent."""
+        container.register_scope("task")
+        container.register(ScopedValue, scope="task", from_context=True)
+
+        async def run_task(label: str) -> str:
+            async with container.ascoped_context("task", replace=True) as ctx:
+                ctx.set(ScopedValue, ScopedValue(label))
+                await asyncio.sleep(0)
+                return (await container.aresolve(ScopedValue)).label
+
+        async with container.ascoped_context("task") as parent_ctx:
+            parent_ctx.set(ScopedValue, ScopedValue("parent"))
+
+            results = await asyncio.gather(
+                run_task("A"),
+                run_task("B"),
+                run_task("C"),
+            )
+
+            assert results == ["A", "B", "C"]
+            assert (await container.aresolve(ScopedValue)).label == "parent"
+
+    async def test_parallel_create_task_isolated_contexts(
+        self, container: Container
+    ) -> None:
+        """Concurrent replaced scopes via create_task don't cross-contaminate.
+
+        create_task copies the current context, so a scope active in the parent
+        is still active inside the child task. replace=True still gives each
+        child an isolated context that leaves the parent untouched.
+        """
+        container.register_scope("task")
+        container.register(ScopedValue, scope="task", from_context=True)
+
+        results: dict[str, str] = {}
+
+        async def run_task(label: str) -> None:
+            async with container.ascoped_context("task", replace=True) as ctx:
+                ctx.set(ScopedValue, ScopedValue(label))
+                await asyncio.sleep(0)
+                resolved = await container.aresolve(ScopedValue)
+                results[label] = resolved.label
+
+        async with container.ascoped_context("task") as parent_ctx:
+            parent_ctx.set(ScopedValue, ScopedValue("parent"))
+
+            tasks = [asyncio.create_task(run_task(f"T{i}")) for i in range(5)]
+            await asyncio.gather(*tasks)
+
+            for i in range(5):
+                assert results[f"T{i}"] == f"T{i}"
+
+            assert container.get_scoped_context("task") is parent_ctx
+            assert (await container.aresolve(ScopedValue)).label == "parent"
+
+    async def test_parallel_replace_with_build(self, container: Container) -> None:
+        """Parallel replaced scopes work correctly after build()."""
+        container.register_scope("task")
+        container.register(int, lambda: 42, scope="singleton")
+        container.register(ScopedValue, scope="task", from_context=True)
+        container.register(DependentService, scope="task")
+
+        container.build()
+
+        async def run_task(label: str) -> tuple[str, int]:
+            async with container.ascoped_context("task", replace=True) as ctx:
+                ctx.set(ScopedValue, ScopedValue(label))
+                await asyncio.sleep(0)
+                svc = await container.aresolve(DependentService)
+                singleton_val = await container.aresolve(int)
+                return svc.value.label, singleton_val
+
+        async with container:
+            async with container.ascoped_context("task") as parent_ctx:
+                parent_ctx.set(ScopedValue, ScopedValue("parent"))
+
+                results = await asyncio.gather(
+                    run_task("A"),
+                    run_task("B"),
+                    run_task("C"),
+                )
+
+                assert [r[0] for r in results] == ["A", "B", "C"]
+                assert all(r[1] == 42 for r in results)
+
+                assert (await container.aresolve(ScopedValue)).label == "parent"
+
+    def test_parallel_threads_isolated_contexts(self, container: Container) -> None:
+        """Concurrent scopes across threads are fully isolated."""
+        container.register_scope("task")
+        container.register(UniqueId, scope="task")
+
+        results: list[tuple[UniqueId, UniqueId]] = []
+
+        def worker() -> None:
+            with container.scoped_context("task"):
+                id1 = container.resolve(UniqueId)
+                id2 = container.resolve(UniqueId)
+                results.append((id1, id2))
+
+        threads = [threading.Thread(target=worker) for _ in range(5)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        for id1, id2 in results:
+            assert id1 is id2
+
+        unique_ids = {id(pair[0]) for pair in results}
+        assert len(unique_ids) == 5
+
+
+class TestReplaceScopeWithTestMode:
+    """Tests for replaced scopes combined with test_mode / override."""
+
+    def test_replace_preserves_outer_deps_in_test_mode(
+        self, container: Container
+    ) -> None:
+        """Outer service attrs still resolve to outer deps inside an inner scope."""
+        container.enable_test_mode()
+        container.register_scope("task")
+        container.register(ScopedValue, scope="task", from_context=True)
+        container.register(DependentService, scope="task")
+
+        with container.scoped_context("task") as ctx_a:
+            ctx_a.set(ScopedValue, ScopedValue("A"))
+            svc_a = container.resolve(DependentService)
+            assert svc_a.value.label == "A"
+
+            with container.scoped_context("task", replace=True) as ctx_b:
+                ctx_b.set(ScopedValue, ScopedValue("B"))
+                svc_b = container.resolve(DependentService)
+                assert svc_b.value.label == "B"
+
+                # While in scope B, outer service must still see scope A's value
+                assert svc_a.value.label == "A"
+
+            assert svc_a.value.label == "A"
+
+    def test_replace_override_in_test_mode(self, container: Container) -> None:
+        """Override works correctly within a nested scope."""
+        container.enable_test_mode()
+        container.register_scope("task")
+        container.register(ScopedValue, scope="task", from_context=True)
+        container.register(DependentService, scope="task")
+
+        with container.scoped_context("task") as ctx:
+            ctx.set(ScopedValue, ScopedValue("real"))
+            svc = container.resolve(DependentService)
+            assert svc.value.label == "real"
+
+            mock_val = ScopedValue("mocked")
+            with container.override(ScopedValue, mock_val):
+                assert svc.value.label == "mocked"
+
+            assert svc.value.label == "real"
+
+    def test_replace_three_levels_test_mode(self, container: Container) -> None:
+        """Three levels of nesting in test_mode preserve per-level deps."""
+        container.enable_test_mode()
+        container.register_scope("task")
+        container.register(ScopedValue, scope="task", from_context=True)
+        container.register(DependentService, scope="task")
+
+        with container.scoped_context("task") as ctx1:
+            ctx1.set(ScopedValue, ScopedValue("L1"))
+            svc1 = container.resolve(DependentService)
+
+            with container.scoped_context("task", replace=True) as ctx2:
+                ctx2.set(ScopedValue, ScopedValue("L2"))
+                svc2 = container.resolve(DependentService)
+
+                with container.scoped_context("task", replace=True) as ctx3:
+                    ctx3.set(ScopedValue, ScopedValue("L3"))
+                    svc3 = container.resolve(DependentService)
+                    assert svc3.value.label == "L3"
+                    assert svc2.value.label == "L2"
+                    assert svc1.value.label == "L1"
+
+                assert svc2.value.label == "L2"
+                assert svc1.value.label == "L1"
+
+            assert svc1.value.label == "L1"


### PR DESCRIPTION
## Summary

Adds a `replace` flag to `scoped_context` / `ascoped_context` so an already-active scope can be re-entered with a **fresh, isolated context** instead of reusing the current one.

Today, entering an already-active scope always reuses the existing context. There is no way to open a fresh, isolated context for a scope that is **already active** while the parent context of that scope stays on the stack. The `replace=True` child gets its own instance cache but can still resolve parent / `singleton` dependencies, and exiting it restores the parent untouched.

## When is this useful?

**1. Concurrent units of work, each with isolated scoped resources.** A parent operation runs in a `db` scope (its own session/transaction) and fans out sub-operations concurrently — each in its own task (`asyncio.gather` copies the contextvar context) and each needing its *own* session, without disturbing the parent's:

```python
container.register_scope("db")

async def handle(item):
    # own task (gather copied the context) + replace=True → own isolated session
    async with container.ascoped_context("db", replace=True):
        session = await container.aresolve(Session)
        await session.execute(insert_result(item))

async with container.ascoped_context("db"):
    outer = await container.aresolve(Session)
    await outer.execute(mark_batch_started())          # parent-level db work
    await asyncio.gather(*(handle(i) for i in items))  # each child: isolated session
    await outer.execute(mark_batch_done())             # parent's session still valid
```

Reusing the parent context here would share one `Session` across concurrent tasks (unsafe) and let a sub-operation commit/rollback the parent's transaction.

**2. Recursive traversal that must keep per-level context.** Walking a tree where each node runs in its own scope and the parent continues using *its* context after the child subtree returns — this can't be flattened to a linear loop, because the parent's scoped state must survive across the recursive call:

```python
container.register_scope("workflow")
container.register(NodeContext, scope="workflow", from_context=True)

async def visit(node) -> list[str]:
    async with container.ascoped_context("workflow", replace=True) as ctx:
        ctx.set(NodeContext, NodeContext(node.id))
        logger = await container.aresolve(NodeLogger)   # bound to THIS node
        logger.log("enter")
        for child in node.children:
            await visit(child)                          # inner replaces the context
        logger.log("exit")                              # still resolves THIS node's context
        return logger.entries
```

On each `visit`, `replace=True` gives the node its own context; when a child subtree returns, the parent's context is restored, so `logger.log("exit")` (and any further resolution) still sees the *parent* node — not the deepest child. Without `replace`, the deepest child's context would leak upward and every level would log against the wrong node.

## What changed

**Public API (`anydi/_container.py`)**

- `scoped_context(scope, *, replace=False)` / `ascoped_context(...)` — new `replace` flag. Default `replace=False` reuses the active context if one exists, otherwise opens a fresh one (unchanged behaviour). `replace=True` always opens a fresh, isolated context that temporarily shadows any active one and is restored on exit.
- `get_scoped_context(scope)` — returns the currently active context for a scope (raises `LookupError` if not started).
- `try_get_scoped_context(scope)` — non-throwing variant, returns `None` when the scope is not active. Prefer these for *reading* the active context; only call `scoped_context` / `ascoped_context` to genuinely **start** a scope.

The default (`replace=False`) is unchanged behaviour, so this is backwards compatible. `replace=True` works on any scope — no separate opt-in on `register_scope`.

**Resolver (`anydi/_resolver.py`)**

- Only affects the **override / test-mode** path (the lazy re-resolution getter is built only when `override_mode` is on — i.e. overrides registered or test-mode enabled; inert in normal resolution).
- That getter previously re-resolved wrapped dependencies through the live global scope var. With a replaced (child) context active, accessing a parent-scope object would then misresolve to the child's dependency. It now resolves against the **context the instance was created in**, so a parent object keeps resolving the parent's dependencies. Covered by the `*_test_mode` tests.
- `Resolver._resolve_wrapped()` was extracted from `_post_resolve_override` (pure refactor — the context-aware lookup pushed the method over ruff's `C901` limit).

## Behaviour-preserving change worth flagging

- **`context_var.reset(token)` moved into a `finally`** in `scoped_context` / `ascoped_context`, so the context var is reset even if the scope body raises. Replacement relies on correct teardown ordering; this also fixes a latent leak on exceptions.

## Tests & docs

- New `tests/test_scope_replace.py`: basic replace, async, instance-cache isolation per level, resource cleanup ordering, `get_scoped_context` / `try_get_scoped_context`, `build()` + compiled resolvers, parallel `asyncio.gather` / `create_task` / threads isolation, and `test_mode` / override interaction.
- `docs/usage/scopes.md`: new "Re-entering an active scope" section.

## Checklist

- `make lint` clean (ty, ruff format, ruff check)
- `make test` green
