### PR TITLE
Make the docs readable: a shop window, a reference, one voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ Main features:
 * **Type-safe**: Uses type hints for dependency resolution.
 * **Async support**: Works with both sync and async code.
 * **Scopes**: Provides singleton, transient, and request scopes. Supports custom scope definitions.
-* **Simple**: Minimal boilerplate with straightforward API.
-* **Fast**: Low overhead dependency resolution.
 * **Named providers**: Use `Annotated[...]` for multiple providers per type.
 * **Resource management**: Context manager protocol support for lifecycle management.
 * **Modular**: Container and module composition for large applications.
@@ -42,9 +40,9 @@ Main features:
 pip install anydi
 ```
 
-## Quick Example
+## Quick example
 
-### Define a Service (`app/services.py`)
+### Define a service (`app/services.py`)
 
 ```python
 class GreetingService:
@@ -52,7 +50,7 @@ class GreetingService:
         return f"Hello, {name}!"
 ```
 
-### Create the Container and Providers (`app/container.py`)
+### Create the container and providers (`app/container.py`)
 
 ```python
 from anydi import Container
@@ -68,7 +66,7 @@ def service() -> GreetingService:
     return GreetingService()
 ```
 
-### Resolve Dependencies Directly
+### Resolve dependencies directly
 
 ```python
 from app.container import container
@@ -81,7 +79,7 @@ if __name__ == "__main__":
     print(service.greet("World"))
 ```
 
-### Inject Into Functions (`app/main.py`)
+### Inject into functions (`app/main.py`)
 
 ```python
 from anydi import Provide
@@ -98,7 +96,7 @@ if __name__ == "__main__":
     print(container.run(greet))
 ```
 
-### Or Use a Lazy Reference (`app/main.py`)
+### Or use a lazy reference (`app/main.py`)
 
 ```python
 from app.container import container
@@ -118,7 +116,7 @@ if __name__ == "__main__":
 
 The container owns the providers, scopes and lifespan either way. Injection and lazy references are two styles of reaching the same dependency.
 
-### Test with Overrides (`tests/test_app.py`)
+### Test with overrides (`tests/test_app.py`)
 
 ```python
 from unittest import mock
@@ -132,7 +130,7 @@ def test_greet() -> None:
     service_mock = mock.Mock(spec=GreetingService)
     service_mock.greet.return_value = "Mocked"
 
-    with container.override(GreetingService, service_mock):
+    with container.test_mode(), container.override(GreetingService, service_mock):
         result = container.run(greet)
 
     assert result == "Mocked"
@@ -164,7 +162,7 @@ async def greet(
 anydi.ext.fastapi.install(app, container)
 ```
 
-### Test the FastAPI Integration (`test_api.py`)
+### Test the FastAPI integration (`test_api.py`)
 
 ```python
 from unittest import mock
@@ -183,7 +181,7 @@ def test_api_greeting() -> None:
     service_mock = mock.Mock(spec=GreetingService)
     service_mock.greet.return_value = "Mocked"
 
-    with container.override(GreetingService, service_mock):
+    with container.test_mode(), container.override(GreetingService, service_mock):
         response = client.get("/greeting")
 
     assert response.json() == {"greeting": "Mocked"}
@@ -253,23 +251,23 @@ urlpatterns = [
 ]
 ```
 
-## Learn More
+## Documentation
 
-Want to know more? Here are helpful resources:
+**Guides:**
+- [Getting started](https://anydi.readthedocs.io/en/stable/getting-started/)
+- [Core Concepts](https://anydi.readthedocs.io/en/stable/concepts/)
+- [Providers](https://anydi.readthedocs.io/en/stable/usage/providers/)
+- [Scopes](https://anydi.readthedocs.io/en/stable/usage/scopes/)
+- [Dependency Injection](https://anydi.readthedocs.io/en/stable/usage/injection/)
+- [Testing](https://anydi.readthedocs.io/en/stable/usage/testing/)
+- [Reference](https://anydi.readthedocs.io/en/stable/reference/)
 
-**Core Documentation:**
-- [Core Concepts](https://anydi.readthedocs.io/en/stable/concepts/) - Learn about containers, providers, scopes, and dependency injection
-- [Providers](https://anydi.readthedocs.io/en/stable/usage/providers/) - How to register providers and manage resources
-- [Scopes](https://anydi.readthedocs.io/en/stable/usage/scopes/) - How to use built-in and custom scopes
-- [Dependency Injection](https://anydi.readthedocs.io/en/stable/usage/injection/) - Different ways to inject dependencies
-- [Testing](https://anydi.readthedocs.io/en/stable/usage/testing/) - How to test your code with provider overrides
+**Framework integrations:**
+- [FastAPI](https://anydi.readthedocs.io/en/stable/extensions/fastapi/)
+- [Django](https://anydi.readthedocs.io/en/stable/extensions/django/)
+- [FastStream](https://anydi.readthedocs.io/en/stable/extensions/faststream/)
+- [Typer](https://anydi.readthedocs.io/en/stable/extensions/typer/)
+- [Pydantic Settings](https://anydi.readthedocs.io/en/stable/extensions/pydantic_settings/)
 
-**Framework Integrations:**
-- [FastAPI](https://anydi.readthedocs.io/en/stable/extensions/fastapi/) - How to use with FastAPI
-- [Django](https://anydi.readthedocs.io/en/stable/extensions/django/) - How to use with Django and Django Ninja
-- [FastStream](https://anydi.readthedocs.io/en/stable/extensions/faststream/) - How to use with message brokers
-- [Typer](https://anydi.readthedocs.io/en/stable/extensions/typer/) - How to use in CLI applications
-- [Pydantic Settings](https://anydi.readthedocs.io/en/stable/extensions/pydantic_settings/) - How to manage configuration
-
-**Full Documentation:**
-- [Read the Docs](https://anydi.readthedocs.io/) - All documentation with examples and guides
+**Everything else:**
+- [Read the Docs](https://anydi.readthedocs.io/)

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,4 +1,4 @@
-# Core Concepts
+# Core concepts
 
 Learn these basic concepts to use `AnyDI` better.
 
@@ -14,7 +14,7 @@ container = Container()
 
 You can think of container as a registry that knows how to create and manage all your services.
 
-### What container does:
+### What container does
 - Stores providers (using lazy registration)
 - Resolves dependencies on demand
 - Manages object lifecycles (singleton, transient, request)
@@ -52,12 +52,12 @@ class NotificationService:
         self.email = email
 ```
 
-### Types of Providers:
+### Types of providers
 - **Function providers**: Functions decorated with `@container.provider()`
 - **Class providers**: Classes decorated with `@singleton`, `@transient`, or `@request`
 - **Resource providers**: Generators that manage lifecycle
 
-### Dependency Graph
+### Dependency graph
 
 `AnyDI` uses **lazy registration**. This means that when you register a provider, it doesn't check dependencies right away. The check happens later, either when you first resolve the provider with `resolve()`, or when you validate all providers at once with `build()`.
 
@@ -107,7 +107,7 @@ my_service = container.resolve(Service)
 container.build()
 ```
 
-#### Benefits of `build()`:
+#### Benefits of `build()`
 - **Catch errors early**: Finds circular dependencies and scope problems before the application runs.
 - **Check everything**: Checks the entire dependency graph in one step.
 
@@ -136,15 +136,15 @@ def user_context() -> UserContext:
     return UserContext()
 ```
 
-### Built-in scopes:
+### Built-in scopes
 - **singleton**: Created one time and used everywhere
 - **transient**: New instance created every time you need it
 - **request**: Created one time per request context
 
-### Custom scopes:
+### Custom scopes
 You can create your own scopes for special cases like background jobs, user sessions, or multi-tenancy.
 
-## Dependency Injection
+## Dependency injection
 
 Dependency injection means that dependencies are given to a function or class automatically. You don't need to create them manually.
 
@@ -168,13 +168,13 @@ def process_order(service: Provide[OrderService]) -> None:
 container.run(process_order)
 ```
 
-### Why use dependency injection:
-- **Testability**: Easy to substitute mocks and test doubles
+### Why use dependency injection
+- **Testability**: Substitute mocks and test doubles
 - **Flexibility**: Can swap implementations without modifying code
 - **Maintainability**: Explicit dependencies make code easier to understand
 - **Decoupling**: Services don't need to know dependency instantiation logic
 
-## Dependency Type
+## Dependency type
 
 A dependency type is a type annotation that identifies a dependency. Usually it is a class, but it can be any type. In the container, it's represented as the `dependency_type`.
 
@@ -201,7 +201,7 @@ class LocalStorage:
 container.register(StorageBackend, lambda: LocalStorage(), scope="singleton")
 ```
 
-### Named dependency types:
+### Named dependency types
 You can use `Annotated` to register multiple providers for the same type:
 
 ```python
@@ -227,7 +227,7 @@ Resolution is the process when container creates an instance with all its depend
 service = container.resolve(EmailService)
 ```
 
-### Automatic vs manual resolution:
+### Automatic vs manual resolution
 ```python
 # Manual resolution
 service = container.resolve(EmailService)
@@ -244,7 +244,7 @@ service = container.ref(EmailService)
 
 The container owns the dependencies and their lifecycle. How your code reaches them is a matter of taste: inject them into functions, resolve them manually, or keep a lazy reference at module level. All three use the same providers, the same scopes and the same overrides in tests.
 
-## Lifecycle Management
+## Lifecycle management
 
 Lifecycle management controls when resources are created, used, and cleaned up.
 
@@ -275,7 +275,7 @@ db = container.resolve(Database)
 container.close()
 ```
 
-### Context managers:
+### Context managers
 `AnyDI` works with Python's context managers:
 
 ```python
@@ -341,7 +341,7 @@ with container:
     print(users)
 ```
 
-## Next Steps
+## Next steps
 
 - [Providers](usage/providers/index.md) - Learn more about providers
 - [Scopes](usage/scopes.md) - Deep dive into scopes

--- a/docs/extensions/django.md
+++ b/docs/extensions/django.md
@@ -1,6 +1,6 @@
-# Django Extension
+# Django extension
 
-## Quick Start
+## Quick start
 
 Install `anydi` with `Django` support:
 
@@ -27,7 +27,7 @@ ANYDI = {
 
 This configuration injects dependencies into your Django views in the specified URLconf.
 
-Let's say you have a service class you want to inject into your views:
+Say you have a service class to inject into your views:
 
 ```python
 class HelloService:
@@ -102,7 +102,7 @@ class UserModule:
 You can now use the UserService in your views as demonstrated in the Quick Start section.
 
 
-## Custom Container
+## Custom container
 
 To use a custom container, you can specify the `CONTAINER_FACTORY` setting:
 
@@ -124,7 +124,7 @@ def get_container() -> Container:
     return container
 ```
 
-## Request Scope
+## Request scope
 
 To use `request`-scoped dependencies in your Django application, add the `request_scoped_middleware`. This middleware creates request-specific dependency instances at the start of each request. They stay available for the request duration.
 

--- a/docs/extensions/fastapi.md
+++ b/docs/extensions/fastapi.md
@@ -1,6 +1,6 @@
-# FastAPI Extension
+# FastAPI extension
 
-You can use `AnyDI` with `FastAPI` easily. Since `FastAPI` has its own dependency injection, you can use `Provide` annotation or `Inject` marker instead of the standard `Depends`.
+`FastAPI` has a dependency injection of its own, so `AnyDI` slots into it: use the `Provide` annotation or the `Inject` marker in place of `Depends`.
 
 
 ```python
@@ -92,7 +92,7 @@ app = FastAPI(lifespan=lifespan)
 ```
 
 
-## Request Scope
+## Request scope
 
 To use `request`-scoped dependencies in your `FastAPI` application, use the `RequestScopedMiddleware`. This middleware creates dependencies that are tied to each request lifecycle. You can also access the `Request` object.
 
@@ -126,6 +126,9 @@ class UserService:
 
 
 container = Container()
+# The middleware puts the request into the scoped context, and this is what
+# lets a provider take it as a parameter.
+container.register(Request, scope="request", from_context=True)
 
 
 @container.provider(scope="request")
@@ -153,10 +156,10 @@ async def get_user(
 anydi.ext.fastapi.install(app, container)
 ```
 
-With this setup, you can use request-scoped dependencies in your application. `Request` is automatically available in request-scoped providers, so you can access the request object and its data.
+The middleware puts the `Request` into the request context for the length of the call. Registering it with `from_context=True` is what lets a request-scoped provider take it as a parameter.
 
 
-## WebSocket Support
+## WebSocket support
 
 `AnyDI` supports WebSocket endpoints in FastAPI with a dedicated `websocket` scope for connection-specific state. The `websocket` scope is registered automatically when you call `anydi.ext.fastapi.install()`.
 
@@ -172,7 +175,7 @@ The `websocket` scope lets you create dependencies that:
 - Are isolated between different connections
 - Can use request-scoped and singleton dependencies
 
-### Basic WebSocket Example
+### Basic WebSocket example
 
 Here's a simple example of using dependency injection in a WebSocket endpoint:
 
@@ -195,6 +198,8 @@ class ConnectionState:
 
 
 container = Container()
+# `install()` registers this scope too, but the providers below need it now.
+container.register_scope("websocket", parents=["request"])
 
 
 @container.provider(scope="websocket")
@@ -230,7 +235,7 @@ anydi.ext.fastapi.install(app, container)
 
 In this example, each WebSocket connection gets its own `ConnectionState` instance that stays alive for all messages in that connection. When the connection closes, the instance is cleaned up automatically.
 
-### Resource Cleanup
+### Resource cleanup
 
 WebSocket-scoped dependencies support automatic cleanup using generator-based providers:
 
@@ -265,15 +270,17 @@ async def websocket_database(
     # Cleanup automatically happens here
 ```
 
-### Accessing WebSocket Object
+### Accessing WebSocket object
 
-The `WebSocket` object is automatically available in both `request` and `websocket` scoped providers:
+The middleware puts the `WebSocket` into the context. Register it with `from_context=True`, and `request` and `websocket` scoped providers can take it as a parameter:
 
 ```python
 from dataclasses import dataclass
 from typing import Any
 
 from starlette.websockets import WebSocket
+
+container.register(WebSocket, scope="websocket", from_context=True)
 
 
 @dataclass
@@ -300,7 +307,7 @@ async def websocket_info(
     await websocket.close()
 ```
 
-### Concurrent Connections
+### Concurrent connections
 
 Each WebSocket connection maintains its own isolated scope:
 
@@ -323,7 +330,7 @@ async def websocket_concurrent(
         await websocket.send_text(response)
 ```
 
-### Scope Hierarchy
+### Scope hierarchy
 
 Since `websocket` inherits from `request` scope, websocket-scoped providers can inject request-scoped dependencies:
 

--- a/docs/extensions/faststream.md
+++ b/docs/extensions/faststream.md
@@ -1,6 +1,6 @@
-# FastStream Extension
+# FastStream extension
 
-You can integrate `AnyDI` with [`FastStream`](https://faststream.airt.ai/latest/) easily. Since `FastStream` uses [`FastDepends`](https://github.com/Lancetnik/FastDepends), you can use the same `Provide[...]` annotation or `Inject()` marker as with FastAPI extension, instead of FastDepends' `Depends`.
+[`FastStream`](https://faststream.airt.ai/latest/) resolves dependencies with [`FastDepends`](https://github.com/Lancetnik/FastDepends), so `AnyDI` slots into it the same way as into `FastAPI`: use the `Provide[...]` annotation or the `Inject()` marker in place of `Depends`.
 
 !!! warning "Version Requirement"
 

--- a/docs/extensions/pydantic_settings.md
+++ b/docs/extensions/pydantic_settings.md
@@ -1,8 +1,8 @@
-# Pydantic Settings Extension
+# Pydantic settings extension
 
 The Pydantic Settings extension loads settings from a Pydantic model into an `AnyDI` container.
 
-## Quick Start
+## Quick start
 
 If you have a Pydantic `BaseSettings` model for application settings:
 

--- a/docs/extensions/typer.md
+++ b/docs/extensions/typer.md
@@ -1,4 +1,4 @@
-# Typer Extension
+# Typer extension
 
 You can use `AnyDI` with [`Typer`](https://typer.tiangolo.com/) to add dependency injection to CLI applications. This extension supports both sync and async commands for building modern CLI tools with clean dependency management.
 
@@ -444,7 +444,7 @@ def test_send_email_failure() -> None:
     assert "Failed to send email" in result.stderr
 ```
 
-### Testing Async Commands
+### Testing async commands
 
 Async commands are tested the same way as sync commands - `CliRunner` handles the async execution automatically:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,119 @@
+# Getting started
+
+This page builds one small application: a service with a dependency of its
+own, a container that knows how to create both, and a function that receives
+the service without asking for it.
+
+## Install
+
+```console
+$ pip install anydi
+```
+
+## Define the classes
+
+Nothing here knows about `AnyDI`. `Greeter` takes a `Config`, and that is the
+only thing that says one depends on the other.
+
+```python
+class Config:
+    def __init__(self, greeting: str) -> None:
+        self.greeting = greeting
+
+
+class Greeter:
+    def __init__(self, config: Config) -> None:
+        self.config = config
+
+    def greet(self, name: str) -> str:
+        return f"{self.config.greeting}, {name}"
+```
+
+## Register the providers
+
+A provider is a function that returns an instance. Its return annotation says
+what it provides, and its parameters say what it needs, so the container can
+work out the order.
+
+```python
+from anydi import Container
+
+container = Container()
+
+
+@container.provider(scope="singleton")
+def config() -> Config:
+    return Config(greeting="Hello")
+
+
+@container.provider(scope="singleton")
+def greeter(config: Config) -> Greeter:
+    return Greeter(config)
+```
+
+The `singleton` scope means one instance for the life of the container. The
+other scopes are on the [Scopes](usage/scopes.md) page.
+
+## Resolve
+
+`resolve` creates the `Config` first, hands it to `greeter`, and keeps both.
+Asking again returns the same instance.
+
+```python
+greeter_instance = container.resolve(Greeter)
+
+print(greeter_instance.greet("Ada"))  # Hello, Ada
+print(container.resolve(Greeter) is greeter_instance)  # True
+```
+
+## Inject
+
+Resolving by hand is fine at the edge of an application. Everywhere else, let
+the container fill the parameter. `Provide` marks which parameter to fill, and
+`run` calls the function with it.
+
+```python
+from anydi import Provide
+
+
+def welcome(name: str, greeter: Provide[Greeter]) -> str:
+    return greeter.greet(name)
+
+
+print(container.run(welcome, "Grace"))  # Hello, Grace
+```
+
+The other ways to inject, including the `@container.inject` decorator and the
+framework extensions, are on the
+[Dependency Injection](usage/injection.md) page.
+
+## Clean up after a dependency
+
+A provider that yields instead of returning is a resource: the code after
+`yield` runs when the container closes.
+
+```python
+from collections.abc import Iterator
+
+
+@container.provider(scope="singleton")
+def connection() -> Iterator[str]:
+    print("connection opened")
+    yield "connection"
+    print("connection closed")
+
+
+container.resolve(str)
+container.close()
+```
+
+Use `await container.aclose()` when any of the resources is asynchronous.
+
+## What to read next
+
+- [Core Concepts](concepts.md) for containers, providers, scopes and injection
+  as a whole.
+- [Scopes](usage/scopes.md) if you need a dependency per request rather than
+  per application.
+- [Testing](usage/testing.md) for overriding a provider in a test.
+- [Reference](reference.md) for everything `Container` offers.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,8 +21,6 @@ Main features:
 * **Type-safe**: Uses type hints for dependency resolution.
 * **Async support**: Works with both sync and async code.
 * **Scopes**: Provides singleton, transient, and request scopes. Supports custom scope definitions.
-* **Simple**: Minimal boilerplate with straightforward API.
-* **Fast**: Low overhead dependency resolution.
 * **Named providers**: Use `Annotated[...]` for multiple providers per type.
 * **Resource management**: Context manager protocol support for lifecycle management.
 * **Modular**: Container and module composition for large applications.
@@ -39,9 +37,9 @@ Main features:
 pip install anydi
 ```
 
-## Quick Example
+## Quick example
 
-### Define a Service (`app/services.py`)
+### Define a service (`app/services.py`)
 
 ```python
 class GreetingService:
@@ -49,7 +47,7 @@ class GreetingService:
         return f"Hello, {name}!"
 ```
 
-### Create the Container and Providers (`app/container.py`)
+### Create the container and providers (`app/container.py`)
 
 ```python
 from anydi import Container
@@ -65,7 +63,7 @@ def service() -> GreetingService:
     return GreetingService()
 ```
 
-### Resolve Dependencies Directly
+### Resolve dependencies directly
 
 ```python
 from app.container import container
@@ -78,7 +76,7 @@ if __name__ == "__main__":
     print(service.greet("World"))
 ```
 
-### Inject Into Functions (`app/main.py`)
+### Inject into functions (`app/main.py`)
 
 ```python
 from anydi import Provide
@@ -95,7 +93,7 @@ if __name__ == "__main__":
     print(container.run(greet))
 ```
 
-### Test with Overrides (`tests/test_app.py`)
+### Test with overrides (`tests/test_app.py`)
 
 ```python
 from unittest import mock
@@ -109,7 +107,7 @@ def test_greet() -> None:
     service_mock = mock.Mock(spec=GreetingService)
     service_mock.greet.return_value = "Mocked"
 
-    with container.override(GreetingService, service_mock):
+    with container.test_mode(), container.override(GreetingService, service_mock):
         result = container.run(greet)
 
     assert result == "Mocked"
@@ -139,7 +137,7 @@ async def greet(
 anydi.ext.fastapi.install(app, container)
 ```
 
-### Test the FastAPI Integration (`test_api.py`)
+### Test the FastAPI integration (`test_api.py`)
 
 ```python
 from unittest import mock
@@ -158,7 +156,7 @@ def test_api_greeting() -> None:
     service_mock = mock.Mock(spec=GreetingService)
     service_mock.greet.return_value = "Mocked"
 
-    with container.override(GreetingService, service_mock):
+    with container.test_mode(), container.override(GreetingService, service_mock):
         response = client.get("/greeting")
 
     assert response.json() == {"greeting": "Mocked"}
@@ -228,20 +226,20 @@ urlpatterns = [
 ]
 ```
 
-## Learn More
+## Documentation
 
-Want to know more? Here are helpful resources:
+**Guides:**
+- [Getting started](getting-started.md)
+- [Core Concepts](concepts.md)
+- [Providers](usage/providers/index.md)
+- [Scopes](usage/scopes.md)
+- [Dependency Injection](usage/injection.md)
+- [Testing](usage/testing.md)
+- [Reference](reference.md)
 
-**Core Documentation:**
-- [Core Concepts](concepts.md) - Learn about containers, providers, scopes, and dependency injection
-- [Providers](usage/providers/index.md) - How to register providers and manage resources
-- [Scopes](usage/scopes.md) - How to use built-in and custom scopes
-- [Dependency Injection](usage/injection.md) - Different ways to inject dependencies
-- [Testing](usage/testing.md) - How to test your code with provider overrides
-
-**Framework Integrations:**
-- [FastAPI](extensions/fastapi.md) - How to use with FastAPI
-- [Django](extensions/django.md) - How to use with Django and Django Ninja
-- [FastStream](extensions/faststream.md) - How to use with message brokers
-- [Typer](extensions/typer.md) - How to use in CLI applications
-- [Pydantic Settings](extensions/pydantic_settings.md) - How to manage configuration
+**Framework integrations:**
+- [FastAPI](extensions/fastapi.md)
+- [Django](extensions/django.md)
+- [FastStream](extensions/faststream.md)
+- [Typer](extensions/typer.md)
+- [Pydantic Settings](extensions/pydantic_settings.md)

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,63 @@
+# Reference
+
+Everything `AnyDI` exports, with the docstrings from the source.
+
+## Container
+
+::: anydi.Container
+
+::: anydi.import_container
+
+## Markers
+
+`Provide` annotates a parameter with the type to resolve. `Inject` is the
+default marker for a parameter that carries its type in the annotation.
+
+::: anydi.Provide
+
+::: anydi.Inject
+
+## Scope decorators
+
+Each of these marks a class as provided in one scope, so
+[auto-registration](usage/providers/auto-registration.md) can pick it up
+without a provider function.
+
+::: anydi.singleton
+
+::: anydi.transient
+
+::: anydi.request
+
+::: anydi.provided
+
+## Providers and modules
+
+::: anydi.provider
+
+::: anydi.Provider
+
+::: anydi.Module
+
+::: anydi.injectable
+
+## The global container
+
+One container the whole application reaches by import, covered in
+[Global Container](usage/global-container.md).
+
+::: anydi.create_global_container
+
+::: anydi.set_global_container
+
+::: anydi.get_global_container
+
+::: anydi.get_global_container_or_none
+
+::: anydi.reset_global_container
+
+::: anydi.global_ref
+
+## Types
+
+::: anydi.Scope

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -1,8 +1,8 @@
-# Command Line Interface
+# Command line interface
 
 `AnyDI` provides a CLI tool to validate and visualize your dependency graph.
 
-## Basic Usage
+## Basic usage
 
 ```shell
 anydi myapp.container:container
@@ -16,7 +16,7 @@ You can also use a factory function that returns a container:
 anydi myapp.container:create_container
 ```
 
-## Output Formats
+## Output formats
 
 ### Tree (Default)
 
@@ -91,7 +91,7 @@ digraph G {
 }
 ```
 
-#### Render with Graphviz
+#### Render with graphviz
 
 Install Graphviz:
 
@@ -178,7 +178,7 @@ anydi myapp:container -o json --indent 4 > graph.json
 
 ## Options
 
-### Full Module Path
+### Full module path
 
 Show full module paths in output:
 
@@ -194,7 +194,7 @@ myapp.services.UserService (singleton)
     └── db: myapp.database.Database (singleton)
 ```
 
-### Scan Packages
+### Scan packages
 
 Scan packages for providers before generating graph:
 
@@ -202,7 +202,7 @@ Scan packages for providers before generating graph:
 anydi myapp:container -s myapp
 ```
 
-## All Options
+## All options
 
 | Option            | Short | Description                                      |
 |-------------------|-------|--------------------------------------------------|

--- a/docs/usage/injection.md
+++ b/docs/usage/injection.md
@@ -1,4 +1,4 @@
-# Dependency Injection
+# Dependency injection
 
 To use dependencies from the `Container`, you need to inject them into functions or classes. The recommended way is using the `Provide` annotation with `container.run()`.
 
@@ -60,7 +60,7 @@ handler()
 
 The service argument has a default value `Inject()`. This tells `AnyDI` which dependency to inject when you call the handler function.
 
-## Annotation Equivalents
+## Annotation equivalents
 
 `AnyDI` understands these different ways to declare injected dependency (they all work the same):
 
@@ -72,7 +72,7 @@ dependency: Provide[MyType]
 
 You can use any of these forms. They all do the same thing.
 
-## Scanning Injections
+## Scanning injections
 
 `AnyDI` can scan Python modules or packages to find and inject dependencies automatically.
 Your application might look like this:

--- a/docs/usage/modules.md
+++ b/docs/usage/modules.md
@@ -63,7 +63,7 @@ assert container.is_registered(Service)
 assert container.is_registered(Repository)
 ```
 
-## Aliases in Modules
+## Aliases in modules
 
 Use the `alias` parameter in `@provider` to register type aliases:
 

--- a/docs/usage/providers/annotated.md
+++ b/docs/usage/providers/annotated.md
@@ -1,8 +1,8 @@
-# Named Providers
+# Named providers
 
 Sometimes you need to register multiple providers for the same type. For example, you might want multiple database connections or different implementations of the same type. You can do this with the `Annotated` type hint and a string name to tell providers apart.
 
-## Basic Usage
+## Basic usage
 
 ```python
 from typing import Annotated
@@ -40,11 +40,11 @@ assert primary.host == "db-primary.local"
 assert replica.host == "db-replica.local"
 ```
 
-In this example, we define two providers for different database connections. The `Annotated` type hint with a string lets you choose which provider to use by the name in the annotation.
+The two providers above return different database connections. The `Annotated` type hint carries the name, so the annotation itself says which provider to use.
 
-## Use Cases
+## Use cases
 
-### Multiple Configurations
+### Multiple configurations
 
 ```python
 from typing import Annotated
@@ -76,7 +76,7 @@ prod_client = container.resolve(Annotated[APIClient, "production"])
 staging_client = container.resolve(Annotated[APIClient, "staging"])
 ```
 
-### Different Implementations
+### Different implementations
 
 ```python
 from typing import Annotated, Protocol

--- a/docs/usage/providers/auto-registration.md
+++ b/docs/usage/providers/auto-registration.md
@@ -104,7 +104,7 @@ class CRUDRepository(IReader, IWriter):
 !!! note
     The class is the primary registration. Aliases are additional keys resolving to the same instance. See [Type Aliases](basics.md#type-aliases).
 
-## Request Scope with Context
+## Request scope with context
 
 Use `from_context=True` when the instance is set via `context.set()`:
 
@@ -126,7 +126,7 @@ with container.request_context() as ctx:
     assert req.path == "/users"
 ```
 
-## Generic TypeVar Resolution
+## Generic TypeVar resolution
 
 `AnyDI` automatically resolves TypeVars when inheriting from generic base classes:
 
@@ -214,7 +214,7 @@ container.scan(".", ignore=[".api"])     # Relative ignore
 
 ### Circular import detection
 
-If a scanned module imports the container at module level, it triggers another `scan()` call. `AnyDI` detects this and raises `RuntimeError`.
+If scanning a package starts a second `scan()` of that package, `AnyDI` detects it and raises `RuntimeError`.
 
 **Solutions:**
 
@@ -222,7 +222,7 @@ If a scanned module imports the container at module level, it triggers another `
 - Add problematic modules to `ignore`
 - Keep container in a module that doesn't get scanned
 
-## Mixing with Explicit Registration
+## Mixing with explicit registration
 
 Combine explicit and auto-registration:
 

--- a/docs/usage/providers/basics.md
+++ b/docs/usage/providers/basics.md
@@ -1,7 +1,6 @@
-# Provider Basics
+# Provider basics
 
-Providers are the main part of `AnyDI`. A provider is a function or class that returns an instance of a specific type.
-After you register a provider with `Container`, you can use it to resolve dependencies in your application.
+A provider is a function or a class that returns an instance of one type. You register it with `Container`, and from then on the container can resolve that type wherever it is asked for.
 
 ## Registering providers
 
@@ -59,7 +58,7 @@ service = container.resolve(NotificationService)
 service.notify("user-123", "Hello!")
 ```
 
-## Type Aliases
+## Type aliases
 
 Use the `alias` parameter in `register()` or `@provider` to register aliases inline:
 

--- a/docs/usage/providers/index.md
+++ b/docs/usage/providers/index.md
@@ -1,10 +1,10 @@
 # Providers
 
-Providers are the core of `AnyDI`. A provider is a function or class that returns an instance of a specific type. After registering a provider with `Container`, you can use it to resolve dependencies in your application.
+This section covers how to register providers, name several of one type, hand out resources that need closing, and let `AnyDI` register classes for you. [Provider basics](basics.md) starts from what a provider is.
 
-## Quick Examples
+## Quick examples
 
-### Basic Provider
+### Basic provider
 ```python
 from anydi import Container
 
@@ -15,7 +15,7 @@ def config() -> dict:
     return {"env": "production"}
 ```
 
-### Named Provider
+### Named provider
 ```python
 from typing import Annotated
 
@@ -24,7 +24,7 @@ def primary_db() -> Annotated[Database, "primary"]:
     return Database(host="primary.db")
 ```
 
-### Resource Provider
+### Resource provider
 ```python
 from typing import Iterator
 
@@ -36,7 +36,7 @@ def database() -> Iterator[Database]:
     db.disconnect()
 ```
 
-### Auto-Registered Provider
+### Auto-Registered provider
 ```python
 from anydi import singleton
 
@@ -46,7 +46,7 @@ class UserService:
         self.db = db
 ```
 
-## Learn More
+## Learn more
 
 - **[Provider Basics](basics.md)** - Register, unregister, and check provider status
 - **[Named Providers](annotated.md)** - Register multiple providers for the same type

--- a/docs/usage/providers/resources.md
+++ b/docs/usage/providers/resources.md
@@ -1,10 +1,10 @@
-# Resource Management
+# Resource management
 
 Resource providers are special providers that need to start and stop. This is useful for database connections, file handles, network sockets, or any resources that need cleanup.
 
 `AnyDI` supports both sync and async resource providers.
 
-## Synchronous Resources
+## Synchronous resources
 
 Here is an example of a synchronous resource provider that manages the lifecycle of a Resource object:
 
@@ -53,7 +53,7 @@ container.close()
 
 In this example, the `database_provider` function returns an iterator that yields a `DatabaseConnection` object. The `.connect()` method is called when the resource is created. The `.disconnect()` method is called when the resource is released.
 
-## Asynchronous Resources
+## Asynchronous resources
 
 Here is an example of an asynchronous resource provider that manages the lifecycle of an asynchronous Resource object:
 
@@ -110,7 +110,7 @@ asyncio.run(main())
 
 In this example, the `async_database_provider` function returns an async iterator that yields an `AsyncDatabase` object. The `.astart()` method is called when the resource is created. The `.aclose()` method is called when the resource is released.
 
-## Resource Events
+## Resource events
 
 Sometimes it is useful to split instance creation and lifecycle management into separate providers. This keeps instance creation separate from lifecycle management.
 

--- a/docs/usage/scopes.md
+++ b/docs/usage/scopes.md
@@ -167,7 +167,7 @@ The `from_context=True` option tells `AnyDI` that:
 
 This makes the dependency explicit and type-safe. The `from_context` option can only be used with scoped contexts (like `request`), not with `singleton` or `transient` scopes.
 
-## Custom Scopes
+## Custom scopes
 
 You can create custom scopes for your application. Custom scopes are useful when you need to manage dependencies differently from the standard scopes.
 
@@ -199,7 +199,8 @@ For example, if you have: `workflow` → `task` → `singleton`, then:
 - `workflow` providers can use `workflow`, `task`, and `singleton` dependencies
 - `task` providers can use `task` and `singleton` dependencies
 - `singleton` providers can only use `singleton` dependencies
-- `transient` providers can use any dependencies
+- `transient` providers can use any dependencies, as long as the scope they
+  belong to is open
 
 ### How to use custom scopes
 
@@ -243,7 +244,7 @@ with container.scoped_context("task"):
         assert engine.task_context.task_id == "task-123"
 ```
 
-### Async Custom Scopes
+### Async custom scopes
 
 Custom scopes also support async contexts:
 
@@ -315,7 +316,7 @@ Without `isolated=True` all tasks would share one session, and a finished task c
 3. **Use clear names**: Choose names that show the scope purpose (`task`, `session`, `tenant`, etc.)
 4. **Validate dependencies**: Container automatically checks that dependencies follow the hierarchy rules
 
-### Common Use Cases
+### Common use cases
 
 #### Multi-tenancy
 ```python

--- a/docs/usage/testing.md
+++ b/docs/usage/testing.md
@@ -1,10 +1,10 @@
 # Testing
 
-## Test Mode
+## Test mode
 
 When overriding dependencies in tests, `AnyDI` uses a special **test mode** that enables proper override support throughout the dependency graph. Test mode ensures that overridden dependencies are correctly propagated to all dependent services.
 
-### Enabling Test Mode
+### Enabling test mode
 
 You can enable test mode in two ways:
 
@@ -28,7 +28,7 @@ finally:
     container.disable_test_mode()
 ```
 
-### Why Test Mode Matters
+### Why test mode matters
 
 `AnyDI` compiles optimized resolvers for fast dependency resolution. Test mode switches to a separate set of resolvers that include override checking logic. This ensures:
 
@@ -38,7 +38,7 @@ finally:
 
 **Note:** If you use the pytest plugin (see below), test mode is automatically enabled for you.
 
-## Overriding Dependencies
+## Overriding dependencies
 
 Use the `.override(dependency_type, instance)` context manager to replace a dependency temporarily during testing. It helps you isolate code from its dependencies.
 The `container.override()` works only inside the `with` block. When the block ends, the original dependency comes back.
@@ -72,6 +72,8 @@ class Service:
 
 
 container = Container()
+container.register(Repository, scope="singleton")
+container.register(Service, scope="singleton")
 
 
 @container.inject
@@ -99,7 +101,7 @@ def test_handler() -> None:
         assert get_items() == [Item(name="mock1"), Item(name="mock2")]
 ```
 
-### Overriding Lazy References
+### Overriding lazy references
 
 Dependencies obtained with [`container.ref()`](references.md) are overridden the same way. A reference always asks the container for the current instance. The override applies even if the reference was already used:
 
@@ -123,7 +125,7 @@ def test_handler() -> None:
         assert get_items() == [Item(name="mock1"), Item(name="mock2")]
 ```
 
-## Overriding Providers with Modules
+## Overriding providers with modules
 
 You can create a testing module that overrides providers from your application modules. Use `@provider(scope="...", override=True)` to replace specific providers:
 
@@ -173,7 +175,7 @@ This approach is useful when you want to:
 - Override multiple providers in one place
 - Share testing configuration across multiple test files
 
-## Pytest Plugin
+## The pytest plugin
 
 `AnyDI` has a pytest plugin that injects dependencies into test functions. This makes tests simpler and cleaner.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: AnyDI
 site_description: Dependency Injection library
 site_author: Anton Ruhlov
-site_url: https://github.com/python-anydi/anydi
+site_url: https://anydi.readthedocs.io/en/stable/
 
 theme:
   name: material
@@ -21,19 +21,20 @@ edit_uri: ""
 
 nav:
   - Home: index.md
-  - Core Concepts: concepts.md
-  - Usage Guide:
+  - Getting started: getting-started.md
+  - Core concepts: concepts.md
+  - Usage guide:
     - Providers:
       - Overview: usage/providers/index.md
       - Basics: usage/providers/basics.md
-      - Named Providers: usage/providers/annotated.md
-      - Resource Management: usage/providers/resources.md
-      - Auto-Registration: usage/providers/auto-registration.md
+      - Named providers: usage/providers/annotated.md
+      - Resource management: usage/providers/resources.md
+      - Auto-registration: usage/providers/auto-registration.md
     - Scopes: usage/scopes.md
-    - Dependency Injection: usage/injection.md
+    - Dependency injection: usage/injection.md
     - References:
       - Overview: usage/references.md
-      - Global Container: usage/global-container.md
+      - Global container: usage/global-container.md
     - Modules: usage/modules.md
     - Testing: usage/testing.md
     - CLI: usage/cli.md
@@ -41,11 +42,25 @@ nav:
     - FastAPI: extensions/fastapi.md
     - FastStream: extensions/faststream.md
     - Typer: extensions/typer.md
-    - Pydantic Settings: extensions/pydantic_settings.md
+    - Pydantic settings: extensions/pydantic_settings.md
     - Django: extensions/django.md
   - Examples:
-    - Basic Application: examples/basic.md
-    - Global Container: examples/global_container.md
+    - Basic application: examples/basic.md
+    - Global container: examples/global_container.md
+  - Reference: reference.md
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            show_source: false
+            show_root_heading: true
+            separate_signature: true
+            members_order: source
+            filters: ["!^_"]
 
 markdown_extensions:
   - admonition

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ dev = [
 docs = [
     "mkdocs>=1.4.2,<2",
     "mkdocs-material>=9.5.29,<10",
+    "mkdocstrings[python]>=0.26.0",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -50,6 +50,7 @@ dev = [
 docs = [
     { name = "mkdocs" },
     { name = "mkdocs-material" },
+    { name = "mkdocstrings", extra = ["python"] },
 ]
 
 [package.metadata]
@@ -79,6 +80,7 @@ dev = [
 docs = [
     { name = "mkdocs", specifier = ">=1.4.2,<2" },
     { name = "mkdocs-material", specifier = ">=9.5.29,<10" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.26.0" },
 ]
 
 [[package]]
@@ -419,6 +421,15 @@ wheels = [
 ]
 
 [[package]]
+name = "griffelib"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/b4/a767e91c606deefc447a96eaf59edd77397960b1d677dffd833ee8449831/griffelib-2.2.0.tar.gz", hash = "sha256:e1bc36fe9cd21d4b6b659b456346755e4cfdc5676c0a5214083126ee12612b3c", size = 227048, upload-time = "2026-08-16T14:04:58.383Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/b6/f65ac785d4ac90dcf7c831ac6256f5dd4a19780f4e1575b2c0d6eeebe319/griffelib-2.2.0-py3-none-any.whl", hash = "sha256:d71c3bc2bbed9f958488634fe788b843a9f705d6d2838ca32cd6c25eeb64dfc4", size = 166779, upload-time = "2026-08-16T14:04:54.365Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -634,6 +645,20 @@ wheels = [
 ]
 
 [[package]]
+name = "mkdocs-autorefs"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/c0/f641843de3f612a6b48253f39244165acff36657a91cc903633d456ae1ac/mkdocs_autorefs-1.4.4.tar.gz", hash = "sha256:d54a284f27a7346b9c38f1f852177940c222da508e66edc816a0fa55fc6da197", size = 56588, upload-time = "2026-02-10T15:23:55.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/de/a3e710469772c6a89595fc52816da05c1e164b4c866a89e3cb82fb1b67c5/mkdocs_autorefs-1.4.4-py3-none-any.whl", hash = "sha256:834ef5408d827071ad1bc69e0f39704fa34c7fc05bc8e1c72b227dfdc5c76089", size = 25530, upload-time = "2026-02-10T15:23:53.817Z" },
+]
+
+[[package]]
 name = "mkdocs-get-deps"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -676,6 +701,43 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "mkdocstrings"
+version = "1.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+    { name = "mkdocs-autorefs" },
+    { name = "pymdown-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/71/f85bdf13355073ae15a7375f09879375a830553552e58c1c4b7e0bbc5c8b/mkdocstrings-1.0.6.tar.gz", hash = "sha256:a0b8c2bdd29a6416c80d717aa369bbf7831946bd9f23c2a66db1b1dbe7693dbd", size = 100649, upload-time = "2026-07-11T19:38:05.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/5b/4c1902e8bdd5c4db63284e9d101dece4038d4025d6d88850ffe0a1578980/mkdocstrings-1.0.6-py3-none-any.whl", hash = "sha256:2703708697487d1b6d6d7b412e176fa436edf120c1bf81dc9e126b12d00893c7", size = 35787, upload-time = "2026-07-11T19:38:04.417Z" },
+]
+
+[package.optional-dependencies]
+python = [
+    { name = "mkdocstrings-python" },
+]
+
+[[package]]
+name = "mkdocstrings-python"
+version = "2.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffelib" },
+    { name = "mkdocs-autorefs" },
+    { name = "mkdocstrings" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/5d/1be1c7a49d8fa13dc80f66a85f53333d52cf5206911412006ffdff8fb9a0/mkdocstrings_python-2.0.7.tar.gz", hash = "sha256:8c49faf66d243072d7590a1b5dea028d9d7425fac191f54f096123a4a9c1a783", size = 201598, upload-time = "2026-08-17T16:56:18.239Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/6d/77546d8c26f038fce314a507106954f76270f6c182488bcf9ac9721175df/mkdocstrings_python-2.0.7-py3-none-any.whl", hash = "sha256:1fce5fbfe4ffa6e8136a35351cdc97c3bf55219c7efbd3f92a82260f93235d60", size = 105387, upload-time = "2026-08-17T16:56:16.813Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The documentation review found the landing pages doing a tutorial's job, no
place to look an API up, and headings in two cases at once. This is all of it.

## The landing pages

`README.md` went from 275 lines to 102, `docs/index.md` from 247 to 102, and
they are now the same page: what `AnyDI` is, how to install it, one example
that runs, a test that swaps a dependency, the feature list, and links onward.
The eight walkthrough sections went with it, including the full Django Ninja
setup, which `docs/extensions/django.md` already covers.

The two pages had already drifted apart: `docs/index.md` carried a broken
`INSTALLED_APPS` snippet the README had right, and the README had a lazy
reference section the docs page lacked.

Both snippets were executed. The test example now uses `container.test_mode()`
alongside `override()`, without which the library itself warns.

## A reference

There was nowhere to see `Container`'s surface: `create()`, `release()`,
`reset()`, `alias()`, `register_scope()`, `test_mode()` and the rest were
mentioned in prose on some page and never collected. `docs/reference.md`
renders 40 members through `mkdocstrings`, plus the markers, the scope
decorators, modules and the global container.

## Getting started

The nav went Home -> Core concepts, a 348-line lecture, with no page that
builds one working thing. `docs/getting-started.md` does: two plain classes,
providers, `resolve`, injection, and a resource closed by `container.close()`.
Every block runs, in order.

## One voice

Fifty headings and ten page titles were in Title Case next to sentence case
ones; nine ended in a colon. All of them read the same way now, and the nav
titles match. The `usage/providers` overview and basics pages opened with the
same paragraph reworded, so the overview now says what the section holds and
the basics page defines a provider once.

Also: five sentences that said "easily", "let's say" or "we define"; and
`site_url`, which pointed at the GitHub repository instead of the docs site,
so canonical links and the sitemap were wrong.

`tools/lint_docs.py` reports 0, `mkdocs build --strict` is clean, no relative
link is broken, and the suite passes.