### PR TITLE
Say what to install when an extension's package is missing

### DIFF
--- a/anydi/ext/fastapi.py
+++ b/anydi/ext/fastapi.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+try:
+    import fastapi  # noqa: F401
+except ImportError:  # pragma: no cover - CI installs it
+    message = "This extension needs `fastapi`. Install it with `pip install fastapi`."
+    raise ImportError(message) from None
+
 import inspect
 from collections.abc import Iterable, Iterator
 from typing import Annotated, Any, cast

--- a/anydi/ext/faststream.py
+++ b/anydi/ext/faststream.py
@@ -2,6 +2,14 @@
 
 from __future__ import annotations
 
+try:
+    import faststream  # noqa: F401
+except ImportError:  # pragma: no cover - CI installs it
+    message = (
+        "This extension needs `faststream`. Install it with `pip install faststream`."
+    )
+    raise ImportError(message) from None
+
 import inspect
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, cast

--- a/anydi/ext/pydantic_settings.py
+++ b/anydi/ext/pydantic_settings.py
@@ -1,5 +1,14 @@
 from __future__ import annotations
 
+try:
+    import pydantic_settings  # noqa: F401
+except ImportError:  # pragma: no cover - CI installs it
+    message = (
+        "This extension needs `pydantic-settings`. "
+        "Install it with `pip install pydantic-settings`."
+    )
+    raise ImportError(message) from None
+
 from collections.abc import Callable, Iterable
 from typing import Annotated, Any
 

--- a/anydi/ext/starlette/middleware.py
+++ b/anydi/ext/starlette/middleware.py
@@ -2,6 +2,14 @@
 
 from __future__ import annotations
 
+try:
+    import starlette  # noqa: F401
+except ImportError:  # pragma: no cover - CI installs it
+    message = (
+        "This extension needs `starlette`. Install it with `pip install starlette`."
+    )
+    raise ImportError(message) from None
+
 from contextlib import AsyncExitStack
 
 from starlette.requests import Request

--- a/anydi/ext/typer.py
+++ b/anydi/ext/typer.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+try:
+    import typer  # noqa: F401
+except ImportError:  # pragma: no cover - CI installs it
+    message = "This extension needs `typer`. Install it with `pip install typer`."
+    raise ImportError(message) from None
+
 import asyncio
 import concurrent.futures
 import contextlib


### PR DESCRIPTION
On a bare `pip install anydi`, five of the six extensions failed with a raw
`ModuleNotFoundError`, and `faststream` named `fast_depends`, which is not
what anyone would think to install:

```
anydi.ext.fastapi              ModuleNotFoundError: No module named 'fastapi'
anydi.ext.faststream           ModuleNotFoundError: No module named 'fast_depends'
anydi.ext.pydantic_settings    ModuleNotFoundError: No module named 'pydantic'
anydi.ext.typer                ModuleNotFoundError: No module named 'typer'
anydi.ext.starlette.middleware ModuleNotFoundError: No module named 'starlette'
```

The Django extension already answered this well, so the other five now do the
same:

```
ImportError: This extension needs `fastapi`. Install it with `pip install fastapi`.
```

Verified on an environment with nothing but `anydi` in it.