### PR TITLE
Keep the base module providers on a subclass

### DIFF
--- a/anydi/_decorators.py
+++ b/anydi/_decorators.py
@@ -161,7 +161,9 @@ class Provided(Protocol):
 
 
 def is_provided(cls: Any) -> TypeGuard[type[Provided]]:
-    return hasattr(cls, "__provided__") and "scope" in cls.__provided__
+    # A subclass inherits `__provided__`, but nobody marked it.
+    metadata = getattr(cls, "__dict__", {}).get("__provided__")
+    return metadata is not None and "scope" in metadata
 
 
 class ProviderMetadata(TypedDict):

--- a/anydi/_module.py
+++ b/anydi/_module.py
@@ -15,11 +15,16 @@ class ModuleMeta(type):
     """A metaclass used for the Module base class."""
 
     def __new__(cls, name: str, bases: tuple[type, ...], attrs: dict[str, Any]) -> Any:
-        attrs["providers"] = [
+        # Keyed by name, so a subclass replaces a provider it redefines.
+        providers: dict[str, ProviderMetadata] = {}
+        for base in reversed(bases):
+            providers.update(getattr(base, "providers", ()))
+        providers.update(
             (name, value.__provider__)
             for name, value in attrs.items()
             if is_provider(value)
-        ]
+        )
+        attrs["providers"] = list(providers.items())
         return super().__new__(cls, name, bases, attrs)
 
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -347,3 +347,27 @@ def test_injectable_decorator_with_tags() -> None:
     assert my_func.__injectable__ == {
         "tags": ["tag1", "tag2"],
     }
+
+
+def test_is_not_provided_by_inheritance() -> None:
+    @singleton
+    class BaseSender:
+        pass
+
+    class SmtpSender(BaseSender):
+        pass
+
+    assert is_provided(BaseSender)
+    assert not is_provided(SmtpSender)
+
+
+def test_a_decorated_subclass_is_provided() -> None:
+    @singleton
+    class BaseSender:
+        pass
+
+    @singleton
+    class SmtpSender(BaseSender):
+        pass
+
+    assert is_provided(SmtpSender)

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -166,3 +166,47 @@ class TestContainerModuleRegistrator:
         cache2 = container.resolve(IStore)
         cache3 = container.resolve(RedisCache)
         assert cache1 is cache2 is cache3
+
+    def test_module_subclass_keeps_the_base_providers(
+        self, container: Container
+    ) -> None:
+        class Config:
+            pass
+
+        class Repo:
+            def __init__(self, config: Config) -> None:
+                self.config = config
+
+        class BaseModule(Module):
+            @provider(scope="singleton")
+            def config(self) -> Config:
+                return Config()
+
+        class AppModule(BaseModule):
+            @provider(scope="singleton")
+            def repo(self, config: Config) -> Repo:
+                return Repo(config=config)
+
+        container.register_module(AppModule)
+
+        assert container.is_registered(Config)
+        assert isinstance(container.resolve(Repo).config, Config)
+
+    def test_module_subclass_replaces_a_provider_it_redefines(
+        self, container: Container
+    ) -> None:
+        class BaseModule(Module):
+            @provider(scope="singleton")
+            def message(self) -> str:
+                return "base"
+
+        class AppModule(BaseModule):
+            @provider(scope="singleton")
+            def message(self) -> str:
+                return "app"
+
+        assert [name for name, _ in AppModule.providers] == ["message"]
+
+        container.register_module(AppModule)
+
+        assert container.resolve(str) == "app"


### PR DESCRIPTION
Two bugs about inheritance, one in modules and one in the `@singleton` family.

## A module subclass lost its base providers

`ModuleMeta.__new__` collected `providers` from `attrs`, the attributes of the
class being defined, so a subclass kept only what it declared itself:

```python
class Base(Module):
    @provider(scope="singleton")
    def name(self) -> str:
        return "base"

class App(Base):
    @provider(scope="singleton")
    def port(self) -> int:
        return 8000

Container(modules=[App]).resolve(str)   # LookupError
```

The metaclass now starts from the bases and applies the class's own providers
on top. The collection is keyed by name, so a subclass that redefines a
provider replaces it instead of the module registering both, and an earlier
base wins over a later one, the way the MRO resolves an attribute.

## An undecorated subclass counted as provided

`is_provided` read `__provided__` with `hasattr`, and the attribute is
inherited, so every subclass of a provided class looked provided. The whole
metadata came with it, including the keys that belong to one class only.

An inherited `alias` registers the same interface twice:

```python
@singleton(alias=Repo)
class SqlRepo: ...

class PostgresRepo(SqlRepo): ...    # nobody marked this one
```

```
ValueError: Alias `repos.Repo` is already registered for `repos.SqlRepo`.
```

An inherited `from_context` claims a registration nobody made:

```
LookupError: The provider `AuthedRequest` is registered with from_context=True
but has not been set in the request context.
```

And `container.scan()` registered every subclass it walked past, whether or
not anyone meant it to be a dependency.

`is_provided` now reads the class's own `__dict__`, the way
`_check_already_provided` already did. Decorating a subclass of a provided
class still works, and a test covers it.

**This changes behaviour.** A subclass that used to resolve by inheriting the
base's scope now raises `LookupError` naming the class and saying to decorate
it. Marking the class, or its own `__provided__`, is the fix. The pattern the
documentation shows, an undecorated base with the decorated class aliased to
it, is unaffected.

`is_provider` next to it stays on `hasattr` on purpose: providers are methods,
and a subclass inheriting one is exactly what the first fix needs.